### PR TITLE
Replace around_filter with around_action

### DIFF
--- a/lib/marginalia/railtie.rb
+++ b/lib/marginalia/railtie.rb
@@ -31,7 +31,7 @@ module Marginalia
         ensure
           Marginalia::Comment.clear!
         end
-        around_filter :record_query_comment
+        around_action :record_query_comment
       end
     end
 


### PR DESCRIPTION
around_filter is deprecated in rails 5+ and will be removed in rails
5.1. Enable marginalia to work with rails 5+ by replacing the use of
around_filter with around_action.